### PR TITLE
Update the navbar and the account management pages

### DIFF
--- a/civil_society_vote/hub/templates/candidate/base.html
+++ b/civil_society_vote/hub/templates/candidate/base.html
@@ -4,25 +4,8 @@
 {% load i18n %}
 
 {% block content %}
-<div class="search-wrapper container is-flex">
-    <form action="{% url 'candidates' %}" method="GET">
-        <div class="field border-b">
-            <p class="control has-icons-right ">
-                <input class="input search-input" type="text" name="q" value="{{ current_search }}" placeholder="{% trans 'Search...' %}">
-                <label class="search-icon">
-                    <span class="icon is-small is-right">
-                        <i class="fas fa-search"></i>
-                    </span>
-                    <input type="submit" style="display: none;"/>
-                </label>
-            </p>
-        </div>
-    </form>
-</div>
-
 
 {% block extra-header %}
-
 
 <div class="container section has-text-centered ">
     <h1 class="title">
@@ -57,8 +40,6 @@
     </div>
 </div>
 
-
-
 {% if current_domain %}
 <div class="container section">
     <h1 class="section-title">{{ current_domain.name }}</h1>
@@ -69,7 +50,7 @@
 {% endblock %}
 
 <div class="container section">
-        {% block left-side-view %}
-        {% endblock %}
+  {% block left-side-view %}
+  {% endblock %}
 </div>
 {% endblock %}

--- a/civil_society_vote/hub/templates/candidate/list.html
+++ b/civil_society_vote/hub/templates/candidate/list.html
@@ -6,6 +6,22 @@
 
 {% block left-side-view %}
 
+<div class="search-wrapper container is-flex">
+    <form action="{% url 'candidates' %}" method="GET">
+        <div class="field border-b">
+            <p class="control has-icons-right ">
+                <input class="input search-input" type="text" name="q" value="{{ current_search }}" placeholder="{% trans 'Search...' %}">
+                <label class="search-icon">
+                    <span class="icon is-small is-right">
+                        <i class="fas fa-search"></i>
+                    </span>
+                    <input type="submit" style="display: none;"/>
+                </label>
+            </p>
+        </div>
+    </form>
+</div>
+
 <h2 class="section-title uppercase">
     {% trans "Candidates" %}
 </h2>

--- a/civil_society_vote/hub/templates/candidate/register_request.html
+++ b/civil_society_vote/hub/templates/candidate/register_request.html
@@ -11,31 +11,57 @@
 
 {% block left-side-view %}
 
-<h2 class="title is-2">{% trans "Propose candidate" %}</h2>
+<div class="columns is-centered">
+  <div class="column is-two-thirds">
 
-<div class="container">
-    {% if messages %}
-        <article class="message is-success">
-        <div class="message-body">
-            {% for message in messages %}
-                {{ message }}
-            {% endfor %}
-        </div>
-        </article>
-    {% else %}
-        <form method="post" enctype="multipart/form-data" >
-            {% csrf_token %}
+    {% if user.orgs.exists %}
 
-            {{ form.non_field_errors }}
+    <div class="tabs is-medium">
+      <ul>
+        <li>
+          <a href="{% url 'ngo-update' user.orgs.first.id %}">Profilul organizatiei</a>
+        </li>
+        <li class="is-active">
+        {% if user.orgs.first.candidate %}
+          <a href="{% url 'candidate-update' user.orgs.first.candidate.id %}">Candidatul meu</a>
+        {% else %}
+          <a href="{% url 'candidate-register-request' %}">Candidatul meu</a>
+        {% endif %}
+        </li>
+        <li><a href="#">Voturile mele</a></li>
+      </ul>
+    </div>
 
-            {% for hidden_field in form.hidden_fields %}
-                {{ hidden_field.errors }}
-            {% endfor %}
-
-            {{ form|crispy }}
-
-            <input class="button is-success is-pulled-right" type="submit" value="{% trans "Propose candidate" %}">
-        </form>
     {% endif %}
+
+    <h2 class="title border-b uppercase">Adauga un candidat</h2>
+
+    <div class="container">
+        {% if messages %}
+            <article class="message is-success">
+            <div class="message-body">
+                {% for message in messages %}
+                    {{ message }}
+                {% endfor %}
+            </div>
+            </article>
+        {% else %}
+            <form method="post" enctype="multipart/form-data" >
+                {% csrf_token %}
+
+                {{ form.non_field_errors }}
+
+                {% for hidden_field in form.hidden_fields %}
+                    {{ hidden_field.errors }}
+                {% endfor %}
+
+                {{ form|crispy }}
+
+                <input class="button is-success is-pulled-right" type="submit" value="{% trans "Propose candidate" %}">
+            </form>
+        {% endif %}
+    </div>
+
+  </div>
 </div>
 {% endblock %}

--- a/civil_society_vote/hub/templates/candidate/update.html
+++ b/civil_society_vote/hub/templates/candidate/update.html
@@ -10,32 +10,60 @@
 {% endblock extra-header %}
 
 {% block left-side-view %}
+<div class="columns is-centered">
+  <div class="column is-two-thirds">
 
-<h2 class="title border-b uppercase">{% trans "Update candidate" %}</h2>
+    {% if user.orgs.exists %}
 
-<div class="container">
-    {% if messages %}
-        <article class="message is-success">
-        <div class="message-body">
-            {% for message in messages %}
-                {{ message }}
-            {% endfor %}
-        </div>
-        </article>
-    {% else %}
-        <form class="ces-form" method="post" enctype="multipart/form-data" >
-            {% csrf_token %}
+    <div class="tabs is-medium">
+      <ul>
+        <li>
+          <a href="{% url 'ngo-update' user.orgs.first.id %}">Profilul organizatiei</a>
+        </li>
+        <li class="is-active">
+        {% if user.orgs.first.candidate %}
+          <a href="{% url 'candidate-update' user.orgs.first.candidate.id %}">Candidatul meu</a>
+        {% else %}
+          <a href="{% url 'candidate-register-request' %}">Candidatul meu</a>
+        {% endif %}
+        </li>
+        <li><a href="#">Voturile mele</a></li>
+      </ul>
+    </div>
 
-            {{ form.non_field_errors }}
-
-            {% for hidden_field in form.hidden_fields %}
-                {{ hidden_field.errors }}
-            {% endfor %}
-
-            {{ form|crispy }}
-
-            <input class="button is-success is-pulled-right" type="submit" value="{% trans "Update candidate" %}">
-        </form>
     {% endif %}
+
+    <h2 class="title border-b uppercase">Editeaza profil candidat</h2>
+
+    <a href="{% url 'candidate-detail' user.orgs.first.candidate.id %}">Vezi profilul public al candidatului</a>
+    <br><br>
+
+    <div class="container">
+        {% if messages %}
+            <article class="message is-success">
+            <div class="message-body">
+                {% for message in messages %}
+                    {{ message }}
+                {% endfor %}
+            </div>
+            </article>
+        {% else %}
+            <form class="ces-form" method="post" enctype="multipart/form-data" >
+                {% csrf_token %}
+
+                {{ form.non_field_errors }}
+
+                {% for hidden_field in form.hidden_fields %}
+                    {{ hidden_field.errors }}
+                {% endfor %}
+
+                {{ form|crispy }}
+
+                <input class="button is-success is-pulled-right" type="submit" value="{% trans "Update candidate" %}">
+            </form>
+        {% endif %}
+    </div>
+
+  </div>
 </div>
 {% endblock %}

--- a/civil_society_vote/hub/templates/header.html
+++ b/civil_society_vote/hub/templates/header.html
@@ -34,52 +34,25 @@
                         </a>
 
                         <a  href="{% url 'about' %}" class="navbar-item">
-                            {% trans "About" %}
+                            Despre platformă
                         </a>
 
-                        <a  href="{% url 'contact' %}" class="navbar-item">
-                            {% trans "Contact" %}
-                        </a>
+                        <div class="navbar-item">|</div>
 
                         {% if request.user.is_authenticated %}
-                        <div class="navbar-item">
-                        <div class="dropdown is-hoverable">
-                          <div class="dropdown-trigger">
-                            <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
-                              <span>{% trans 'Account' %}</span>
-                              <span class="icon is-small">
-                                <i class="fas fa-angle-down" aria-hidden="true"></i>
-                              </span>
-                            </button>
-                          </div>
-                          <div class="dropdown-menu" id="dropdown-menu" role="menu">
-                            <div class="dropdown-content">
-                            {% if user.orgs.exists %}
-                              {% if user.orgs.first.candidate %}
-                              <a href="{% url 'candidate-detail' user.orgs.first.candidate.id %}" class="navbar-item">
-                                {% trans "View candidate page" %}
-                              </a>
-                              <a href="{% url 'candidate-update' user.orgs.first.candidate.id %}" class="navbar-item">
-                                {% trans "Update candidate info" %}
-                              </a>
-                              {% else %}
-                              <a href="{% url 'candidate-register-request' %}" class="navbar-item">
-                                {% trans "Add candidate" %}
-                              </a>
-                              {% endif %}
-                              <a href="{% url 'ngo-detail' user.orgs.first.id %}" class="navbar-item">
-                                {% trans "View organization page" %}
-                              </a>
-                              <a href="{% url 'ngo-update' user.orgs.first.id %}" class="navbar-item">
-                                {% trans "Update organization info" %}
-                              </a>
+
+                        {% if user.orgs.exists %}
+                          <a href="{% url 'ngo-update' user.orgs.first.id %}" class="navbar-item">
+                            {% if user.orgs.first.logo %}
+                            <img src="{{ user.orgs.first.logo.url }}" alt="{{ user.orgs.first.name }}" style="height:39px; padding-right:10px;">
+                            {% else %}
+                            <img src="{% static 'images/logo-demo.png' %}" alt="{{ user.orgs.first.name }}" style="height:39px;">
                             {% endif %}
-                              <hr class="dropdown-divider">
-                              <a href="{% url 'logout' %}" class="dropdown-item" style="color:red;">{% trans "Logout" %}</a>
-                            </div>
-                          </div>
-                        </div>
-                        </div>
+                            {{ user.orgs.first.name }}
+                          </a>
+                        {% endif %}
+
+                        <a href="{% url 'logout' %}" class="navbar-item">{% trans "Logout" %}</a>
 
                         {% if user.is_impersonate %}
                         <a  href="{% url 'impersonate-stop' %}" class="navbar-item" style="color:red; text-align:center;">

--- a/civil_society_vote/hub/templates/home.html
+++ b/civil_society_vote/hub/templates/home.html
@@ -4,21 +4,6 @@
 {% load i18n %}
 
 {% block content %}
-<div class="search-wrapper container is-flex">
-    <form action="{% url 'candidates' %}" method="GET">
-        <div class="field border-b">
-            <p class="control has-icons-right ">
-                <input class="input search-input" type="text" name="q" value="{{ current_search }}" placeholder="{% trans 'Search...' %}">
-                <label class="search-icon">
-                    <span class="icon is-small is-right">
-                        <i class="fas fa-search"></i>
-                    </span>
-                    <input type="submit" style="display: none;"/>
-                </label>
-            </p>
-        </div>
-    </form>
-</div>
 
 <div class="container section has-text-centered">
     <h1 class="title">Forul Societății Civile</h1>

--- a/civil_society_vote/hub/templates/ngo/base.html
+++ b/civil_society_vote/hub/templates/ngo/base.html
@@ -4,21 +4,6 @@
 {% load i18n %}
 
 {% block content %}
-<div class="search-wrapper container is-flex">
-    <form action="{% url 'ngos' %}" method="GET">
-        <div class="field border-b">
-            <p class="control has-icons-right ">
-                <input class="input search-input" type="text" name="q" value="{{ current_search }}" placeholder="{% trans 'Search...' %}">
-                <label class="search-icon">
-                    <span class="icon is-small is-right">
-                        <i class="fas fa-search"></i>
-                    </span>
-                    <input type="submit" style="display: none;"/>
-                </label>
-            </p>
-        </div>
-    </form>
-</div>
 
 <div class="container">
 
@@ -42,24 +27,24 @@
     {% block domain-filters %}
 
     <div class="container section">
-        <div class="filter-grid">
-            {% for domain in domains %}
-            {% if current_domain.id == domain.id %}
-            <a class="has-text-black filter-link" href="{% spurl base='{{ current_url }}' remove_query_param='domain' remove_query_param='page' %}">
-                <div class="card filter-card-active">
-                    {% else%}
-                    <a class="has-text-black filter-link" href="{% spurl base='{{ current_url }}' set_query='domain={{ domain.id }}' remove_query_param='page' %}">
-                        <div class="card filter-card ">
-                            {% endif %}
-                            <div class="filter-icon">
-                                <i class="far fa-check-circle"></i>
-                            </div>
-                            <div class="filter-card-content">{{ domain.name }}</div>
-                        </div>
-                    </a>
-                    {% endfor %}
-                </div>
-        </div>
+      <div class="filter-grid">
+        {% for domain in domains %}
+        {% if current_domain.id == domain.id %}
+        <a class="has-text-black filter-link" href="{% spurl base='{{ current_url }}' remove_query_param='domain' remove_query_param='page' %}">
+            <div class="card filter-card-active">
+        {% else %}
+        <a class="has-text-black filter-link" href="{% spurl base='{{ current_url }}' set_query='domain={{ domain.id }}' remove_query_param='page' %}">
+            <div class="card filter-card ">
+        {% endif %}
+              <div class="filter-icon">
+                  <i class="far fa-check-circle"></i>
+              </div>
+              <div class="filter-card-content">{{ domain.name }}</div>
+            </div>
+        </a>
+        {% endfor %}
+      </div>
+    </div>
 
     {% if current_domain %}
     <div class="container mb-50">
@@ -74,13 +59,11 @@
 
     {% endblock %}
 
-    <div class="columns is-centered">
-
-        <div class="column is-two-thirds">
-            {% block left-side-view %}
-            {% endblock %}
-        </div>
-
+    <div class="columns is-centered section">
+      <div class="column is-two-thirds">
+          {% block left-side-view %}
+          {% endblock %}
+      </div>
     </div>
 
 </div>

--- a/civil_society_vote/hub/templates/ngo/list.html
+++ b/civil_society_vote/hub/templates/ngo/list.html
@@ -5,6 +5,23 @@
 
 
 {% block left-side-view %}
+
+<div class="search-wrapper container is-flex">
+    <form action="{% url 'ngos' %}" method="GET">
+        <div class="field border-b">
+            <p class="control has-icons-right ">
+                <input class="input search-input" type="text" name="q" value="{{ current_search }}" placeholder="{% trans 'Search...' %}">
+                <label class="search-icon">
+                    <span class="icon is-small is-right">
+                        <i class="fas fa-search"></i>
+                    </span>
+                    <input type="submit" style="display: none;"/>
+                </label>
+            </p>
+        </div>
+    </form>
+</div>
+
 <div class="container">
     <h2 class="ngo-list-title">
         {% trans "Organizations list" %}

--- a/civil_society_vote/hub/templates/ngo/register_request.html
+++ b/civil_society_vote/hub/templates/ngo/register_request.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-
 {% block domain-filters %}
 {% endblock domain-filters %}
 

--- a/civil_society_vote/hub/templates/ngo/update.html
+++ b/civil_society_vote/hub/templates/ngo/update.html
@@ -11,7 +11,30 @@
 
 {% block left-side-view %}
 
-<h2 class="title border-b uppercase">{% trans "Update organization" %}</h2>
+{% if user.orgs.exists %}
+
+<div class="tabs is-medium">
+  <ul>
+    <li class="is-active">
+      <a href="{% url 'ngo-update' user.orgs.first.id %}">Profilul organizatiei</a>
+    </li>
+    <li>
+    {% if user.orgs.first.candidate %}
+      <a href="{% url 'candidate-update' user.orgs.first.candidate.id %}">Candidatul meu</a>
+    {% else %}
+      <a href="{% url 'candidate-register-request' %}">Candidatul meu</a>
+    {% endif %}
+    </li>
+    <li><a href="#">Voturile mele</a></li>
+  </ul>
+</div>
+
+{% endif %}
+
+<h2 class="title border-b uppercase">Profilul organizatiei</h2>
+
+<a href="{% url 'ngo-detail' user.orgs.first.id %}">Vezi profilul public al organizatiei</a>
+<br><br>
 
 <div class="container">
     {% if messages %}

--- a/civil_society_vote/static/css/hub.css
+++ b/civil_society_vote/static/css/hub.css
@@ -2,7 +2,7 @@
     font-family: 'Open Sans', sans-serif;
     font-style: normal;
     font-size: 14px;
-    --accent-color: #5E72E4;
+    /* --accent-color: #5E72E4; */
     --footer-color: #172B4D;
     --dark-gray: #32325D;
     --light-gray: #525F7F;
@@ -82,7 +82,7 @@ body {
 }
 
 .navbar-item {
-    color: #fff;
+    /* color: #fff; */
     font-size: 14px;
     font-weight: 600;
 }


### PR DESCRIPTION
- Remove the search bar in all pages except the organization and
  candidate lists.
- Remove the `Contact` menu button, there is already a link in the
  footer for the contact page.
- Add account menu item that shows the name and logo of the
  organization. The dropdown menu item is replaced by this and the links
  there are moved in the account page which defaults to the organization
  update page.
- The organization and candidate update pages will have a tabed
  navigation between the various account items that an organization will
  be able to edit or view.
