### PR TITLE
Have a consistent user settings navigation

### DIFF
--- a/civil_society_vote/hub/templates/header.html
+++ b/civil_society_vote/hub/templates/header.html
@@ -53,23 +53,18 @@
 
                         {% avatar user 65 class="img-circle img-responsive nav-avatar" id="user_avatar" %}
 
-                        {% if user|in_committee_group %}
-                        <a href="{% url 'committee-ngos' %}" class="navbar-item">
+                        <a href="{% url 'account-password-reset' %}" class="navbar-item">
                             {{ user.email }}
                         </a>
+
+                        {% if user|in_committee_group %}
+                            <a href="{% url 'committee-ngos' %}" class="navbar-item">
+                                {% trans "Vote" %}
+                            </a>
                         {% elif user.orgs.exists %}
-                        <a href="{% url 'ngo-update' user.orgs.first.id %}" class="navbar-item">
-                            {% if user.orgs.first.logo %}
-                            <img src="{{ user.orgs.first.logo.url }}" alt="{{ user.orgs.first.name }}" style="height:39px; padding-right:10px;">
-                            {% else %}
-                            <img src="{% static 'images/logo-demo.png' %}" alt="{{ user.orgs.first.name }}" style="height:39px;">
-                            {% endif %}
-                            {{ user.orgs.first.name }}
-                        </a>
-                        {% else %}
-                        <a href="{% url 'account-password-reset' %}" class="navbar-item">
-                        {{ user.email }}
-                        </a>
+                            <a href="{% url 'ngo-update' user.orgs.first.id %}" class="navbar-item">
+                                {{ user.orgs.first.name }}
+                            </a>
                         {% endif %}
 
                         <a href="{% url 'logout' %}" class="navbar-item">{% trans "Logout" %}</a>


### PR DESCRIPTION
Organization settings and committee voting pages were hidden under the same interaction, under the user's email in the navbar.

I've tried to unify and make them consistent. When a user click's on its email, it'll be redirected to the user's settings. For the organization's settings and committee voting, I've created separate navigation items (explicit is better than implicit).

For staff:
<img width="372" alt="Screenshot 2020-10-05 at 13 40 26" src="https://user-images.githubusercontent.com/639771/95070665-1ef2d000-0711-11eb-8477-ff5d88570353.png">

For NGO:
<img width="367" alt="Screenshot 2020-10-05 at 13 40 05" src="https://user-images.githubusercontent.com/639771/95070666-1f8b6680-0711-11eb-90aa-3b526beb7fb2.png">

For committee:
<img width="365" alt="Screenshot 2020-10-05 at 13 40 41" src="https://user-images.githubusercontent.com/639771/95070661-1d290c80-0711-11eb-9ed2-413215e0ffdd.png">

Closes https://github.com/code4romania/votong/issues/89
