### PR TITLE
Temporarily changed the no results text for candidate search

### DIFF
--- a/civil_society_vote/hub/templates/candidate/list.html
+++ b/civil_society_vote/hub/templates/candidate/list.html
@@ -108,7 +108,8 @@
 
     {% else %}
     <div class="content is-medium">
-        <p style="text-align: center;">{% trans "No results matching query" %}</p>
+        <!-- replace bellow trans with "No results matching query" when data is added -->
+        <p style="text-align: center;">{% trans "Aici vei putea vedea candidaturile propuse de pentru Consiliul Economic și Social pe măsură ce ele devin publice." %}</p>
     </div>
     {% endif %}
 </div>


### PR DESCRIPTION
### What does it fix?

Replaced the no entry results text for candidate results

Closes #145 