### PR TITLE
Add counts to the candidate detail view in admin

### DIFF
--- a/civil_society_vote/hub/admin.py
+++ b/civil_society_vote/hub/admin.py
@@ -265,10 +265,55 @@ class CandidateAdmin(admin.ModelAdmin):
         "votes_count",
         "created",
     ]
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": (
+                    "org",
+                    "initial_org",
+                    "name",
+                    "domain",
+                    "description",
+                    "cv",
+                    "role",
+                    "experience",
+                    "studies",
+                    "main_objectives",
+                    "main_points",
+                    "relevant_moments",
+                    "email",
+                    "phone",
+                    "photo",
+                    "mandate",
+                    "letter",
+                    "statement",
+                    "tax_records",
+                    "legal_records",
+                    "is_proposed",
+                    "status",
+                    "status_changed",
+                    "modified",
+                    "created",
+                    "supporters_count",
+                    "confirmations_count",
+                    "votes_count",
+                )
+            },
+        ),
+    ]
     list_filter = ["is_proposed", "status", CandidateSupportersListFilter, CandidateConfirmationsListFilter, "domain"]
     search_fields = ["name", "email", "org__name"]
-    readonly_fields = ["status", "status_changed"]
-    inlines = [CandidateConfirmationInline, CandidateSupporterInline, CandidateVoteInline]
+    readonly_fields = [
+        "status",
+        "status_changed",
+        "supporters_count",
+        "confirmations_count",
+        "votes_count",
+        "modified",
+        "created",
+    ]
+    inlines = [CandidateSupporterInline, CandidateConfirmationInline, CandidateVoteInline]
     actions = [accept_candidates, reject_candidates, pending_candidates]
     list_per_page = 20
 


### PR DESCRIPTION
Closes #189

This is pretty ugly and if we add new fields to the candidate we have to make sure to sync them here. If we can live with having the vote count just in the candidate list and not here I would avoid merging this and have less maintenance hassle. 